### PR TITLE
Add Elispeak to 口语练习

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@
 - [HelloTalk](https://www.hellotalk.com/) - 寻找语言伙伴
 - [Speechling](https://speechling.com/) - 获取发音反馈
 - [SmallTalk2Me](https://smalltalk2.me/) - AI驱动的口语练习工具
+- [Elispeak](https://app.elispeak.com/?freemium=true) - AI英语口语陪练，可就日常、工作、旅行及雅思/托福话题进行真实语音对话，每天15分钟免费练习
 - [发音技巧舌位图解](https://www.bilibili.com/video/BV1Ji4y1P7Lu) - 有具体舌位图，对发音很有帮助
 
 ## 视频学习


### PR DESCRIPTION
在 口语练习 一节里新增 **Elispeak** 一行，紧跟在 SmallTalk2Me 之后（同属 AI 驱动口语练习类）。

[Elispeak](https://app.elispeak.com/?freemium=true) 是一个 AI 英语口语陪练：用户可以就日常、工作、旅行、雅思 / 托福话题直接出声对话，获得自然回复与纠错。每天 15 分钟练习免费，浏览器端使用，无需安装。

单行新增，不改动其他条目顺序。感谢维护这份清单！