### PR TITLE
实用工具：添加 LeafyApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@
 - [WordPecker App](https://github.com/baturyilmaz/wordpecker-app) - Duolingo风格的交互式英语学习工具
 - [MuJing](https://github.com/tangshimin/MuJing) - 通过电影、美剧或文档中的真实语境学习英语单词的应用
 - [Comic Translate](https://github.com/ogkalu2/comic-translate) - 一个自动翻译漫画的开源项目
+- [Leafy](https://leafyapp.uk) - Mac 上的屏幕取词生词本，按 ⌥A 框住屏幕上任意一个词，把这个词连同它所在的整句一起存进词库，PDF、视频字幕、图片里的词也能取，之后可以用挖空原句的方式复习
 ## 适合应试
 
 适合单纯为了应付考试而学习的英语🧐

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@
 - [WordPecker App](https://github.com/baturyilmaz/wordpecker-app) - Duolingo风格的交互式英语学习工具
 - [MuJing](https://github.com/tangshimin/MuJing) - 通过电影、美剧或文档中的真实语境学习英语单词的应用
 - [Comic Translate](https://github.com/ogkalu2/comic-translate) - 一个自动翻译漫画的开源项目
-- [Leafy](https://leafyapp.uk) - Mac 上的屏幕取词生词本，按 ⌥A 框住屏幕上任意一个词，把这个词连同它所在的整句一起存进词库，PDF、视频字幕、图片里的词也能取，之后可以用挖空原句的方式复习
+- [LeafyApp](https://leafyapp.uk) - Mac 上的屏幕取词生词本，按 ⌥A 框住屏幕上任意一个词，把这个词连同它所在的整句一起存进词库，PDF、视频字幕、图片里的词也能取，之后可以用挖空原句的方式复习
 ## 适合应试
 
 适合单纯为了应付考试而学习的英语🧐


### PR DESCRIPTION
在「实用工具」里加了 Leafy。

它是一个 Mac 上的屏幕取词生词本：按 ⌥A 框住屏幕上任意一个词，识别的时候把这个词所在的整句也一起读出来，词和句子一起存进词库。因为读的是屏幕不是网页，PDF、扫描书、视频字幕、图片里的词都能取，浏览器插件够不着的地方它能用。存下来的词之后可以用挖空原句的方式复习。

免费，macOS 14+，原生 Swift，不需要注册。

利益相关：我是这个 App 的作者，觉得跟这一栏里的工具是同类，不合适的话直接关掉就行。
